### PR TITLE
Add moonfly theme

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -155,6 +155,14 @@ them based you your `background` option.
 <img width='700' src='https://user-images.githubusercontent.com/41551030/108648958-b12b2300-74bc-11eb-8232-550949cbbfb3.png'/>
 </p>
 
+### moonfly
+<p>
+<img width='700' src='https://user-images.githubusercontent.com/11382509/129304429-cd2af22d-3b88-4c17-bf99-99f7608576d4.png'/>
+<img width='700' src='https://user-images.githubusercontent.com/11382509/129304441-81a6c88e-364c-476a-9050-0ada4cae1e3b.png'/>
+<img width='700' src='https://user-images.githubusercontent.com/11382509/129304453-2b18900a-13a9-4476-9977-3875e55aabaf.png'/>
+<img width='700' src='https://user-images.githubusercontent.com/11382509/129304469-37fb0168-0484-406b-8b2e-d309232612ab.png'/>
+</p>
+
 ### nightfly
 <p>
 <img width='700' src='https://user-images.githubusercontent.com/41551030/108648974-b9835e00-74bc-11eb-9c52-c5187aa3ff2c.png'/>

--- a/lua/lualine/themes/moonfly.lua
+++ b/lua/lualine/themes/moonfly.lua
@@ -1,0 +1,41 @@
+-- moonfly color scheme for lualine
+--
+-- URL:     github.com/bluz71/vim-moonfly-colors
+-- License: MIT (https://opensource.org/licenses/MIT)
+
+-- LuaFormatter off
+local colors = {
+  color3   = '#303030',
+  color6   = '#9e9e9e',
+  color7   = '#80a0ff',
+  color8   = '#ae81ff',
+  color0   = '#1c1c1c',
+  color1   = '#ff5189',
+  color2   = '#c6c6c6',
+}
+
+-- LuaFormatter on
+return {
+  replace = {
+    a = {fg = colors.color0, bg = colors.color1, gui = 'bold'},
+    b = {fg = colors.color2, bg = colors.color3}
+  },
+  inactive = {
+    a = {fg = colors.color6, bg = colors.color3, gui = 'bold'},
+    b = {fg = colors.color6, bg = colors.color3},
+    c = {fg = colors.color6, bg = colors.color3}
+  },
+  normal = {
+    a = {fg = colors.color0, bg = colors.color7, gui = 'bold'},
+    b = {fg = colors.color2, bg = colors.color3},
+    c = {fg = colors.color2, bg = colors.color3}
+  },
+  visual = {
+    a = {fg = colors.color0, bg = colors.color8, gui = 'bold'},
+    b = {fg = colors.color2, bg = colors.color3}
+  },
+  insert = {
+    a = {fg = colors.color0, bg = colors.color2, gui = 'bold'},
+    b = {fg = colors.color2, bg = colors.color3}
+  }
+}


### PR DESCRIPTION
Hello again,

Author of [moonfly](https://github.com/bluz71/vim-moonfly-colors) and [nightfly](https://github.com/bluz71/vim-nightfly-guicolors) speaking again.

We spoke a week or so back (at the main lualine repo).

I noted that my nightfly theme had already been added to lualine but moonfly had not. 
I did add both lualine themes to my original Vim theme projects.

However, I don't see the harm in adding moonfly here as well. It is a form of advertising which is nice.

Doing it here since I think the orginal lualine author is not active at the moment.

Cheers.
