### PR TITLE
perf : improve redraw performence

### DIFF
--- a/lua/lualine/component.lua
+++ b/lua/lualine/component.lua
@@ -147,6 +147,8 @@ local Component = {
 
   -- variable to store component output for manipulation
   status = '',
+  last_status = '',
+  last_result = '',
   -- Actual function that updates a component. Must be overwritten with component functionality
   -- luacheck: push no unused args
   update_status = function(self, is_focused) end,
@@ -154,14 +156,17 @@ local Component = {
 
   -- Driver code of the class
   draw = function(self, default_highlight, is_focused)
+    if self.options.condition ~= nil and self.options.condition() ~= true then
+      return ''
+    end
+    local status, use_last_status = self:update_status(is_focused)
+    if status == self.last_result or use_last_status then
+      return self.last_status
+    end
+    self.last_result = status
+    if self.options.format then status = self.options.format(status or '') end
     self.status = ''
     self.applied_separator = ''
-
-    if self.options.condition ~= nil and self.options.condition() ~= true then
-      return self.status
-    end
-    local status = self:update_status(is_focused)
-    if self.options.format then status = self.options.format(status or '') end
     if type(status) == 'string' and #status > 0 then
       self.status = status
       self:apply_icon()
@@ -171,6 +176,7 @@ local Component = {
       self:apply_section_separators()
       self:apply_separator()
     end
+    self.last_status = self.status
     return self.status
   end
 }

--- a/lua/lualine/components/diagnostics.lua
+++ b/lua/lualine/components/diagnostics.lua
@@ -15,6 +15,8 @@ Diagnostics.default_colors = {
   info  = '#ffffff',
   hint  = '#d7afaf',
 }
+
+Diagnostics.last_data = {}
 -- LuaFormatter on
 
 local function color_deprecation_notice(color, opt_name)
@@ -152,6 +154,8 @@ Diagnostics.update_status = function(self)
     info = info_count,
     hint = hint_count
   }
+  if vim.deep_equal(data) == Diagnostics.last_data then return '', true end
+  Diagnostics.last_data = data
   if self.options.colored then
     local colors = {}
     for name, hl in pairs(self.highlight_groups) do

--- a/lua/lualine/components/diff.lua
+++ b/lua/lualine/components/diff.lua
@@ -23,6 +23,7 @@ Diff.default_colors = {
 }
 
 local diff_cache = {} -- Stores last known value of diff of a buffer
+Diff.last_data = {}
 
 local function color_deprecation_notice(color, opt_name)
   utils_notices.add_notice(string.format([[
@@ -130,6 +131,7 @@ Diff.update_status = function(self, is_focused)
 
   if not is_focused then git_diff = diff_cache[vim.fn.bufnr()] or {} end
   if git_diff == nil then return '' end
+  if vim.deep_equal(git_diff, Diff.last_data) then return '', true end
 
   local colors = {}
   if self.options.colored then

--- a/lua/lualine/components/filename.lua
+++ b/lua/lualine/components/filename.lua
@@ -1,6 +1,7 @@
 -- Copyright (c) 2020-2021 shadmansaleh
 -- MIT license, see LICENSE for more details.
 local FileName = require('lualine.component'):new()
+FileName.last_data = ''
 
 local function count(base, pattern)
   return select(2, string.gsub(base, pattern, ''))
@@ -45,6 +46,8 @@ FileName.update_status = function(self)
   end
 
   if data == '' then data = '[No Name]' end
+  if data == FileName.last_data then return '', true end
+  FileName.last_data = data
 
   if self.options.shorting_target ~= 0 then
     local windwidth = vim.fn.winwidth(0)

--- a/lua/lualine/components/filetype.lua
+++ b/lua/lualine/components/filetype.lua
@@ -4,6 +4,7 @@ local highlight = require('lualine.highlight')
 local utils = require('lualine.utils.utils')
 
 local FileType = require('lualine.component'):new()
+FileType.last_data = ''
 
 function FileType:new(options, child)
   local new_instance = self._parent:new(options, child or FileType)
@@ -16,7 +17,12 @@ function FileType:new(options, child)
   return new_instance
 end
 
-function FileType.update_status() return vim.bo.filetype or '' end
+function FileType.update_status()
+  local ft = vim.bo.filetype
+  if ft == FileType.last_data then return '', true end
+  FileType.last_data = ft
+  return ft or ''
+end
 
 function FileType:apply_icon()
   if not self.options.icons_enabled then return end

--- a/lua/tests/spec/component_spec.lua
+++ b/lua/tests/spec/component_spec.lua
@@ -277,7 +277,9 @@ describe('Filetype component', function()
       component_separators = {'', ''},
       padding = 0
     })
-    assert_component('filetype', opts, 'lua')
+    vim.bo.filetype = 'test1'
+    assert_component('filetype', opts, 'test1')
+    vim.bo.filetype = 'lua'
   end)
 
   it('colors nvim-web-devicons icons', function()
@@ -298,13 +300,15 @@ describe('Filetype component', function()
       component_separators = {'', ''},
       padding = 0,
     })
-    assert_component('filetype', opts, '%#MyCompHl_normal#*%#lualine_c_normal# lua')
+    vim.bo.filetype = 'test2'
+    assert_component('filetype', opts, '%#MyCompHl_normal#*%#lualine_c_normal# test2')
     assert.stub(utils.extract_highlight_colors).was_called_with('test_highlight_group', 'fg')
     assert.stub(hl.create_component_highlight_group).was_called_with(
       {fg = '#000'}, 'test_highlight_group', opts
     )
     hl.create_component_highlight_group:revert()
     utils.extract_highlight_colors:revert()
+    vim.bo.filetype = 'lua'
     package.loaded['nvim-web-devicons'] = nil
   end)
 
@@ -325,9 +329,11 @@ describe('Filetype component', function()
       padding = 0,
       colored = false,
     })
-    assert_component('filetype', opts, '* lua')
+    vim.bo.filetype = 'test3'
+    assert_component('filetype', opts, '* test3')
     hl.create_component_highlight_group:revert()
     utils.extract_highlight_colors:revert()
+    vim.bo.filetype = 'lua'
     package.loaded['nvim-web-devicons'] = nil
   end)
 


### PR DESCRIPTION
Caches processed component results . When component returns the same thing previous processed result is used instead of processing the new one . I'm not completely sure if this is useful . This speeds up redraw but redraw is already quite fast and really the section separators are what needs optimization if we want faster redraw. But I can't think of something better for section separators ;/